### PR TITLE
Fix broken links in courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ It makes it easier for new people to find this repository.
 | [edX](https://www.edx.org/) | Fuel your ambition - explore 4000+ courses |
 | [Scrimba](https://scrimba.com/) | Frontend career path helps motivated students become hireable developers for the fraction of the cost of a bootcamp |
 | [Test Automation University](https://testautomationu.applitools.com/) | Become a test automation superstar - Free! |
-| [Udemy] (https://www.udemy.com) | Learn or teach on udemy.com |
-| [w3schools] (https://www.w3schools.com) | Learn to Code |
+| [Udemy](https://www.udemy.com) | Learn or teach on udemy.com |
+| [w3schools](https://www.w3schools.com) | Learn to Code |
 
 ## CSS
 


### PR DESCRIPTION
Ensuring the links for Udemy and w3schools work.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
## Fixes Issue
Closes #55.

## Changes proposed
Remove spaces from hyperlinks so that they show correctly.

## Check List
- [x] Addresses an existing open issue: Closes #55
- [x] The title of my pull request is a short description of the requested changes.
- [x] I followed the [Contributing Guidelines](https://github.com/codu-code/codu/blob/develop/CONTRIBUTING.md) 

## Screenshots
Links were showing like this:
![Image](https://github.com/user-attachments/assets/34a14dbd-cdf9-4ac7-bedd-cd64bb8bdcef)

After the fix they appear like this, consistent with the other hyperlinks:
![{783956B3-C976-465D-B40C-2998D8F903B7}](https://github.com/user-attachments/assets/28ef5b8b-5589-447e-92e5-4616c38ad4b9)
